### PR TITLE
feat(tags): Implement AI-powered automatic file tagging

### DIFF
--- a/src/api/tag.ts
+++ b/src/api/tag.ts
@@ -11,4 +11,5 @@ export type TagDTO = {
   subTags: ID[];
   /** Whether any files with this tag should be hidden */
   isHidden: boolean;
+  isAi: boolean;
 };

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -56,6 +56,7 @@ export default class Backend implements DataStorage {
           subTags: [],
           color: '',
           isHidden: false,
+          isAi: false,
         });
       }
     });

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -82,6 +82,11 @@ export const FileViewerMenuItems = ({ file }: { file: ClientFile }) => {
         icon={IconSet.TAG}
       />
       <MenuItem
+        onClick={uiStore.aiTagSelection}
+        text="AI Tag Selection"
+        icon={IconSet.TAG}
+      />
+      <MenuItem
         onClick={handleRemoveAllTags}
         text="Remove All Tags"
         icon={IconSet.DELETE}

--- a/src/frontend/containers/Outliner/LocationsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/LocationsPanel/index.tsx
@@ -142,7 +142,7 @@ const DirectoryMenu = observer(
     location: ClientLocation | ClientSubLocation;
     onExclude: (subLocation: ClientSubLocation) => void;
   }) => {
-    const { uiStore } = useStore();
+    const { uiStore, fileStore } = useStore();
 
     const path = location instanceof ClientLocation ? location.path : location.path;
 
@@ -158,6 +158,11 @@ const DirectoryMenu = observer(
       [path, uiStore],
     );
 
+    const handleAiTagDirectory = useCallback(
+      () => fileStore.aiTagDirectory(path),
+      [path, fileStore],
+    );
+
     return (
       <>
         <MenuItem onClick={handleAddToSearch} text="Add to Search Query" icon={IconSet.SEARCH} />
@@ -165,6 +170,12 @@ const DirectoryMenu = observer(
           onClick={handleReplaceSearch}
           text="Replace Search Query"
           icon={IconSet.REPLACE}
+        />
+        <MenuDivider />
+        <MenuItem
+          onClick={handleAiTagDirectory}
+          text="AI Tag this Directory"
+          icon={IconSet.TAG_GROUP}
         />
         <MenuDivider />
         {location instanceof ClientSubLocation && (

--- a/src/frontend/containers/Settings/Advanced.tsx
+++ b/src/frontend/containers/Settings/Advanced.tsx
@@ -14,6 +14,7 @@ import ExternalLink from 'src/frontend/components/ExternalLink';
 export const Advanced = observer(() => {
   const { uiStore, fileStore } = useStore();
   const thumbnailDirectory = uiStore.thumbnailDirectory;
+  const aiTagUrl: string = fileStore.aiTagUrl;
 
   const [defaultThumbnailDir, setDefaultThumbnailDir] = useState('');
   useEffect(() => {
@@ -73,6 +74,12 @@ export const Advanced = observer(() => {
         <h3 className="filepicker-label">Thumbnail Directory</h3>
         <div className="filepicker-path">{thumbnailDirectory}</div>
       </div>
+
+      <h3>AI Tagging API</h3>
+      <Callout icon={IconSet.INFO}>
+        A tagging service such as <ExternalLink url="https://github.com/cmeka/media-tag-service">media-tag-service</ExternalLink> must be running.
+      </Callout>
+      <input name="aiTagUrl" defaultValue={aiTagUrl} size={40} onChange={fileStore.setAiTagUrl}></input>
 
       <h3>Development</h3>
       <ButtonGroup>

--- a/src/frontend/entities/File.ts
+++ b/src/frontend/entities/File.ts
@@ -117,6 +117,16 @@ export class ClientFile {
     return this.annotations;
   }
 
+  @computed get hasAiTags(): boolean {
+    if (this.tags.size === 0) return false;
+    for (const obj of this.tags) {
+      if (obj.isAi === true) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @action.bound setThumbnailPath(thumbnailPath: string): void {
     this.thumbnailPath = thumbnailPath;
   }

--- a/src/frontend/entities/Tag.ts
+++ b/src/frontend/entities/Tag.ts
@@ -19,6 +19,7 @@ export class ClientTag {
   @observable name: string;
   @observable color: string;
   @observable isHidden: boolean;
+  @observable isAi: boolean;
   @observable private _parent: ClientTag | undefined;
   readonly subTags = observable<ClientTag>([]);
   // icon, (fileCount?)
@@ -37,6 +38,7 @@ export class ClientTag {
     dateAdded: Date,
     color: string,
     isHidden: boolean,
+    isAi: boolean,
   ) {
     this.store = store;
     this.id = id;
@@ -45,6 +47,7 @@ export class ClientTag {
     this.color = color;
     this.fileCount = 0;
     this.isHidden = isHidden;
+    this.isAi = isAi;
 
     // observe all changes to observable fields
     this.saveHandler = reaction(
@@ -199,6 +202,7 @@ export class ClientTag {
       color: this.color,
       subTags: this.subTags.map((subTag) => subTag.id),
       isHidden: this.isHidden,
+      isAi: this.isAi,
     };
   }
 

--- a/src/frontend/stores/TagStore.ts
+++ b/src/frontend/stores/TagStore.ts
@@ -86,9 +86,9 @@ class TagStore {
     );
   }
 
-  @action.bound async create(parent: ClientTag, tagName: string): Promise<ClientTag> {
+  @action.bound async create(parent: ClientTag, tagName: string, isAiTag: boolean = false): Promise<ClientTag> {
     const id = generateId();
-    const tag = new ClientTag(this, id, tagName, new Date(), '', false);
+    const tag = new ClientTag(this, id, tagName, new Date(), '', false, isAiTag);
     this.tagGraph.set(tag.id, tag);
     tag.setParent(parent);
     parent.subTags.push(tag);
@@ -96,8 +96,8 @@ class TagStore {
     return tag;
   }
 
-  @action findByName(name: string): ClientTag | undefined {
-    return this.tagList.find((t) => t.name === name);
+  @action findByName(name: string, isAiTag: boolean = false): ClientTag | undefined {
+    return this.tagList.find((t) => t.name === name && t.isAi === isAiTag);
   }
 
   @action.bound async delete(tag: ClientTag): Promise<void> {
@@ -161,10 +161,10 @@ class TagStore {
 
   @action private createTagGraph(backendTags: TagDTO[]) {
     // Create tags
-    for (const { id, name, dateAdded, color, isHidden } of backendTags) {
+    for (const { id, name, dateAdded, color, isHidden, isAi } of backendTags) {
       // Create entity and set properties
       // We have to do this because JavaScript does not allow multiple constructor.
-      const tag = new ClientTag(this, id, name, dateAdded, color, isHidden);
+      const tag = new ClientTag(this, id, name, dateAdded, color, isHidden, isAi);
       // Add to index
       this.tagGraph.set(tag.id, tag);
     }

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -549,6 +549,12 @@ class UiStore {
     }
   }
 
+  @action.bound aiTagSelection(): void {
+    if (this.fileSelection.size > 0) {
+      this.rootStore.fileStore.aiTagFiles([...this.fileSelection]);
+    }
+  }
+
   @action.bound closeToolbarTagPopover(): void {
     this.isToolbarTagPopoverOpen = false;
   }

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -22,6 +22,7 @@ describe('Backend', () => {
     color: '',
     subTags: [],
     isHidden: false,
+    isAi: false,
   };
 
   const mockLocationPath = 'c:/test';


### PR DESCRIPTION
I've implemented a feature that leverages local AI models to automatically tag files:

- Integrates with a local API service for AI-powered media tagging
- Files are processed in parallel with 4 concurrent API requests
- AI-generated tags are marked in the system to prevent duplicate processing and maintain distinction from user-created tags

The implementation connects to a local AI tagging service via API calls (configurable in Advanced settings).  
I've created a supporting service https://github.com/cmeka/media-tag-service as I couldn't find an existing solution.

I'm a fan of this application and developed this feature to enhance its capabilities and reduce manual tagging work.  
I'm open to any modifications or suggestions to better align with the project.  
This is my first contribution to an Electron-based project, so any feedback is welcome.  

## Future considerations
- Allow the number of concurrent API requests to be configurable
- Add UI options to filter/manage/remove AI-created tags