### PR TITLE
Fix loading progress display format

### DIFF
--- a/src/frontend/stores/LocationStore.ts
+++ b/src/frontend/stores/LocationStore.ts
@@ -412,7 +412,7 @@ class LocationStore {
 
       AppToaster.show(
         {
-          message: `Loading ${percentage}% \n ${totalFormatted}/${completedFormatted}`,
+          message: `Loading ${percentage}% \n ${completedFormatted}/${totalFormatted}`,
           timeout: 0,
         },
         toastKey,


### PR DESCRIPTION
Fix the loading count display to show `loaded/total` instead of `total/loaded` during reindexing.

---
<a href="https://cursor.com/background-agent?bcId=bc-eef44405-83aa-4e24-a4c2-43582bcf3dd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eef44405-83aa-4e24-a4c2-43582bcf3dd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

