### PR TITLE
Add Version Number to Advanced Settings

### DIFF
--- a/src/frontend/containers/Settings/Advanced.tsx
+++ b/src/frontend/containers/Settings/Advanced.tsx
@@ -53,6 +53,22 @@ export const Advanced = observer(() => {
 
   return (
     <>
+      <h3>Application Information</h3>
+      <div style={{
+        padding: '12px',
+        backgroundColor: 'var(--input-color)',
+        border: '1px solid var(--border-color)',
+        borderRadius: '4px',
+        marginBottom: '20px'
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontWeight: '500' }}>Version:</span>
+          <span style={{ fontFamily: 'monospace', fontSize: '14px' }}>
+            {RendererMessenger.getVersion()}
+          </span>
+        </div>
+      </div>
+
       {/* Todo: Add support to toggle this */}
       {/* <Switch checked={true} onChange={() => alert('Not supported yet')} label="Generate thumbnails" /> */}
       <Callout icon={IconSet.INFO}>


### PR DESCRIPTION
Fixes: #122 

Description
Added the current application version display to the Advanced settings tab.

<img width="687" height="484" alt="Screenshot 2025-09-21 at 17 32 43" src="https://github.com/user-attachments/assets/d8c0ae32-6aca-41b2-9ea5-09031ee215fa" />


Changes:

Added "Application Information" section in Advanced settings
Displays current version using [RendererMessenger.getVersion()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Styled with consistent UI components matching the existing design

Location: Settings → Advanced → Application Information